### PR TITLE
Vendor support

### DIFF
--- a/dart/build_rules/core.bzl
+++ b/dart/build_rules/core.bzl
@@ -99,6 +99,7 @@ _dart_library_attrs = {
     ),
     "pub_pkg_name": attr.string(default=""),
     "deps": attr.label_list(providers = ["dart"]),
+    "force_ddc_compile": attr.bool(default = False),
     "license_files": attr.label_list(allow_files = True),
     "web_exclude_srcs": attr.label_list(allow_files = True),
     "_analyzer": attr.label(

--- a/dart/build_rules/ddc.bzl
+++ b/dart/build_rules/ddc.bzl
@@ -12,6 +12,12 @@ def ddc_action(ctx, dart_ctx, ddc_output, source_map_output):
   """ddc compile action."""
   flags = []
 
+  if ctx.attr.force_ddc_compile:
+    print("Force compile %s?" % ctx.label.name
+          + " sounds a bit too strong for a library that is"
+          + " not strong clean, doesn't it?")
+    flags.append("--unsafe-force-compile")
+
   # TODO: workaround for ng2/templates until they are better typed
   flags.append("--unsafe-angular2-whitelist")
 
@@ -60,7 +66,11 @@ def ddc_action(ctx, dart_ctx, ddc_output, source_map_output):
     inputs.append(f)
     normalized_path = make_package_uri(dart_ctx, f.short_path)
     flags += ["--url-mapping", "%s,%s" % (normalized_path, f.path)]
-    flags += ["--bazel-mapping", "%s,/%s" % (f.path, f.short_path)]
+    if f.short_path.startswith("../"):
+      real_short_path = f.short_path.replace("../", "")
+    else:
+      real_short_path = f.short_path
+    flags += ["--bazel-mapping", "%s,%s" % (f.path, real_short_path)]
     input_paths.append(normalized_path)
 
   # We normalized file:/// paths, so '/' corresponds to the top of google3.

--- a/dart/build_rules/dev_server.bzl
+++ b/dart/build_rules/dev_server.bzl
@@ -3,9 +3,9 @@ load("//dart/build_rules:vm.bzl", "dart_vm_binary")
 def dev_server(name, data=[], deps=[], **kwargs):
   dart_vm_binary(
       name = name,
-      srcs = ["//dart/tools/dev_server:bin/server.dart"],
+      srcs = ["@io_bazel_rules_dart//dart/tools/dev_server:bin/server.dart"],
       data = data,
-      script_file = "//dart/tools/dev_server:bin/server.dart",
-      deps = ["//dart/tools/dev_server:server"] + deps,
+      script_file = "@io_bazel_rules_dart//dart/tools/dev_server:bin/server.dart",
+      deps = ["@io_bazel_rules_dart//dart/tools/dev_server:server"] + deps,
       **kwargs
   )

--- a/dart/build_rules/internal.bzl
+++ b/dart/build_rules/internal.bzl
@@ -287,6 +287,8 @@ def filter_files(filetypes, files):
   return filtered_files
 
 def make_package_uri(dart_ctx, short_path, prefix=""):
+  if short_path.startswith("../"):
+    short_path = short_path.replace("../","")
   if short_path.startswith(dart_ctx.lib_root):
     return "package:%s/%s" % (
         dart_ctx.package, short_path[len(dart_ctx.lib_root):])

--- a/dart/build_rules/internal.bzl
+++ b/dart/build_rules/internal.bzl
@@ -120,7 +120,9 @@ def make_dart_context(label,
     else:
       package = pub_pkg_name
   if not lib_root:
-    if label.workspace_root.startswith("external/"):
+    if label.package.startswith("vendor/"):
+      lib_root = "%s/lib/" % label.package[7:]
+    elif label.workspace_root.startswith("external/"):
       lib_root = "%s/lib/" % label.workspace_root[len("external/"):]
     elif not label.package:
       lib_root = "lib/"
@@ -241,6 +243,8 @@ def layout_action(ctx, srcs, output_dir):
     output_dir += "/"
   for src_file in srcs:
     short_better_path = src_file.short_path
+    if "vendor_" in short_better_path:
+      short_better_path = short_better_path.replace("vendor_", "")
     if short_better_path.startswith('../'):
       dest_file = ctx.new_file(output_dir + short_better_path.replace("../", ""))
     else:

--- a/dart/build_rules/pub.bzl
+++ b/dart/build_rules/pub.bzl
@@ -45,133 +45,133 @@ pub_repository = repository_rule(
 
 def pub_repositories():
   pub_repository(
-      name = "args",
+      name = "vendor_args",
       output = ".",
       package = "args",
       version = "0.13.6",
   )
 
   pub_repository(
-      name = "async",
+      name = "vendor_async",
       output = ".",
       package = "async",
       version = "1.11.2",
   )
 
   pub_repository(
-      name = "charcode",
+      name = "vendor_charcode",
       output = ".",
       package = "charcode",
       version = "1.1.0",
   )
 
   pub_repository(
-      name = "collection",
+      name = "vendor_collection",
       output = ".",
       package = "collection",
       version = "1.9.1",
   )
 
   pub_repository(
-      name = "convert",
+      name = "vendor_convert",
       output = ".",
       package = "convert",
       version = "2.0.1",
   )
 
   pub_repository(
-      name = "csslib",
+      name = "vendor_csslib",
       output = ".",
       package = "csslib",
       version = "0.13.2",
   )
 
   pub_repository(
-      name = "html",
+      name = "vendor_html",
       output = ".",
       package = "html",
       version = "0.13.0",
   )
 
   pub_repository(
-      name = "http_parser",
+      name = "vendor_http_parser",
       output = ".",
       package = "http_parser",
       version = "3.0.3",
   )
 
   pub_repository(
-      name = "logging",
+      name = "vendor_logging",
       output = ".",
       package = "logging",
       version = "0.11.3+1",
   )
 
   pub_repository(
-      name = "mime",
+      name = "vendor_mime",
       output = ".",
       package = "mime",
       version = "0.9.3",
   )
 
   pub_repository(
-      name = "path",
+      name = "vendor_path",
       output = ".",
       package = "path",
       version = "1.4.0",
   )
 
   pub_repository(
-      name = "shelf",
+      name = "vendor_shelf",
       output = ".",
       package = "shelf",
       version = "0.6.5+3",
   )
 
   pub_repository(
-      name = "shelf_static",
+      name = "vendor_shelf_static",
       output = ".",
       package = "shelf_static",
       version = "0.2.4",
   )
 
   pub_repository(
-      name = "source_span",
+      name = "vendor_source_span",
       output = ".",
       package = "source_span",
       version = "1.2.3",
   )
 
   pub_repository(
-      name = "stack_trace",
+      name = "vendor_stack_trace",
       output = ".",
       package = "stack_trace",
       version = "1.6.8",
   )
 
   pub_repository(
-      name = "stream_channel",
+      name = "vendor_stream_channel",
       output = ".",
       package = "stream_channel",
       version = "1.5.0",
   )
 
   pub_repository(
-      name = "string_scanner",
+      name = "vendor_string_scanner",
       output = ".",
       package = "string_scanner",
       version = "1.0.0",
   )
 
   pub_repository(
-      name = "typed_data",
+      name = "vendor_typed_data",
       output = ".",
       package = "typed_data",
       version = "1.1.3",
   )
 
   pub_repository(
-      name = "utf",
+      name = "vendor_utf",
       output = ".",
       package = "utf",
       version = "0.9.0+3",

--- a/vendor/args/BUILD
+++ b/vendor/args/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "args",
     srcs = [
-        "@args//:args"
+        "@vendor_args//:args"
     ],
-    license_files = ["@args//:LICENSE_FILES"],
+    license_files = ["@vendor_args//:LICENSE_FILES"],
     pub_pkg_name = "args",
     deps = [
     ],

--- a/vendor/async/BUILD
+++ b/vendor/async/BUILD
@@ -5,12 +5,11 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "async",
     srcs = [
-        "@async//:async"
+        "@vendor_async//:async"
     ],
-    license_files = ["@async//:LICENSE_FILES"],
+    license_files = ["@vendor_async//:LICENSE_FILES"],
     pub_pkg_name = "async",
     deps = [
         "//vendor/collection",
     ],
 )
-

--- a/vendor/charcode/BUILD
+++ b/vendor/charcode/BUILD
@@ -5,10 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "charcode",
     srcs = [
-        "@charcode//:charcode"
+        "@vendor_charcode//:charcode"
     ],
     pub_pkg_name = "charcode",
     deps = [
     ],
 )
-

--- a/vendor/collection/BUILD
+++ b/vendor/collection/BUILD
@@ -5,11 +5,10 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "collection",
     srcs = [
-        "@collection//:collection"
+        "@vendor_collection//:collection"
     ],
-    license_files = ["@collection//:LICENSE_FILES"],
+    license_files = ["@vendor_collection//:LICENSE_FILES"],
     pub_pkg_name = "collection",
     deps = [
     ],
 )
-

--- a/vendor/convert/BUILD
+++ b/vendor/convert/BUILD
@@ -5,13 +5,12 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "convert",
     srcs = [
-        "@convert//:convert"
+        "@vendor_convert//:convert"
     ],
-    license_files = ["@convert//:LICENSE_FILES"],
+    license_files = ["@vendor_convert//:LICENSE_FILES"],
     pub_pkg_name = "convert",
     deps = [
         "//vendor/charcode",
         "//vendor/typed_data",
     ],
 )
-

--- a/vendor/csslib/BUILD
+++ b/vendor/csslib/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "csslib",
     srcs = [
-        "@csslib//:csslib"
+        "@vendor_csslib//:csslib"
     ],
-    license_files = ["@csslib//:LICENSE_FILES"],
+    license_files = ["@vendor_csslib//:LICENSE_FILES"],
     pub_pkg_name = "csslib",
     deps = [
         "//vendor/args",

--- a/vendor/html/BUILD
+++ b/vendor/html/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "html",
     srcs = [
-        "@html//:html"
+        "@vendor_html//:html"
     ],
-    license_files = ["@html//:LICENSE_FILES"],
+    license_files = ["@vendor_html//:LICENSE_FILES"],
     pub_pkg_name = "html",
     deps = [
         "//vendor/csslib",

--- a/vendor/http_parser/BUILD
+++ b/vendor/http_parser/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "http_parser",
     srcs = [
-        "@http_parser//:http_parser"
+        "@vendor_http_parser//:http_parser"
     ],
-    license_files = ["@http_parser//:LICENSE_FILES"],
+    license_files = ["@vendor_http_parser//:LICENSE_FILES"],
     pub_pkg_name = "http_parser",
     deps = [
       "//vendor/collection",
@@ -15,4 +15,3 @@ dart_library(
       "//vendor/string_scanner",
     ],
 )
-

--- a/vendor/logging/BUILD
+++ b/vendor/logging/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "logging",
     srcs = [
-        "@logging//:logging"
+        "@vendor_logging//:logging"
     ],
-    license_files = ["@logging//:LICENSE_FILES"],
+    license_files = ["@vendor_logging//:LICENSE_FILES"],
     pub_pkg_name = "logging",
     deps = [
     ],

--- a/vendor/mime/BUILD
+++ b/vendor/mime/BUILD
@@ -5,11 +5,10 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "mime",
     srcs = [
-        "@mime//:mime"
+        "@vendor_mime//:mime"
     ],
-    license_files = ["@mime//:LICENSE_FILES"],
+    license_files = ["@vendor_mime//:LICENSE_FILES"],
     pub_pkg_name = "mime",
     deps = [
     ],
 )
-

--- a/vendor/path/BUILD
+++ b/vendor/path/BUILD
@@ -4,9 +4,9 @@ package(default_visibility = ["//visibility:public"])
 
 dart_library(
     name = "path",
-    license_files = ["@path//:LICENSE_FILES"],
+    license_files = ["@vendor_path//:LICENSE_FILES"],
     pub_pkg_name = "path",
     srcs = [
-        "@path//:path"
+        "@vendor_path//:path"
     ],
 )

--- a/vendor/shelf/BUILD
+++ b/vendor/shelf/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "shelf",
     srcs = [
-        "@shelf//:shelf"
+        "@vendor_shelf//:shelf"
     ],
-    license_files = ["@shelf//:LICENSE_FILES"],
+    license_files = ["@vendor_shelf//:LICENSE_FILES"],
     pub_pkg_name = "shelf",
     deps = [
         "//vendor/async",
@@ -17,4 +17,3 @@ dart_library(
         "//vendor/stream_channel",
     ],
 )
-

--- a/vendor/shelf_static/BUILD
+++ b/vendor/shelf_static/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "shelf_static",
     srcs = [
-        "@shelf_static//:shelf_static"
+        "@vendor_shelf_static//:shelf_static"
     ],
-    license_files = ["@shelf_static//:LICENSE_FILES"],
+    license_files = ["@vendor_shelf_static//:LICENSE_FILES"],
     pub_pkg_name = "shelf_static",
     deps = [
         "//vendor/convert",
@@ -17,4 +17,3 @@ dart_library(
         "//vendor/shelf",
     ],
 )
-

--- a/vendor/source_span/BUILD
+++ b/vendor/source_span/BUILD
@@ -5,12 +5,11 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "source_span",
     srcs = [
-        "@source_span//:source_span"
+        "@vendor_source_span//:source_span"
     ],
-    license_files = ["@source_span//:LICENSE_FILES"],
+    license_files = ["@vendor_source_span//:LICENSE_FILES"],
     pub_pkg_name = "source_span",
     deps = [
         "//vendor/path",
     ],
 )
-

--- a/vendor/stack_trace/BUILD
+++ b/vendor/stack_trace/BUILD
@@ -5,12 +5,11 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "stack_trace",
     srcs = [
-        "@stack_trace//:stack_trace"
+        "@vendor_stack_trace//:stack_trace"
     ],
-    license_files = ["@stack_trace//:LICENSE_FILES"],
+    license_files = ["@vendor_stack_trace//:LICENSE_FILES"],
     pub_pkg_name = "stack_trace",
     deps = [
         "//vendor/path",
     ],
 )
-

--- a/vendor/stream_channel/BUILD
+++ b/vendor/stream_channel/BUILD
@@ -5,13 +5,12 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "stream_channel",
     srcs = [
-        "@stream_channel//:stream_channel"
+        "@vendor_stream_channel//:stream_channel"
     ],
-    license_files = ["@stream_channel//:LICENSE_FILES"],
+    license_files = ["@vendor_stream_channel//:LICENSE_FILES"],
     pub_pkg_name = "stream_channel",
     deps = [
         "//vendor/async",
         "//vendor/stack_trace",
     ],
 )
-

--- a/vendor/string_scanner/BUILD
+++ b/vendor/string_scanner/BUILD
@@ -5,13 +5,12 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "string_scanner",
     srcs = [
-        "@string_scanner//:string_scanner"
+        "@vendor_string_scanner//:string_scanner"
     ],
-    license_files = ["@string_scanner//:LICENSE_FILES"],
+    license_files = ["@vendor_string_scanner//:LICENSE_FILES"],
     pub_pkg_name = "string_scanner",
     deps = [
         "//vendor/charcode",
         "//vendor/source_span",
     ],
 )
-

--- a/vendor/typed_data/BUILD
+++ b/vendor/typed_data/BUILD
@@ -5,11 +5,10 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "typed_data",
     srcs = [
-        "@typed_data//:typed_data"
+        "@vendor_typed_data//:typed_data"
     ],
-    license_files = ["@typed_data//:LICENSE_FILES"],
+    license_files = ["@vendor_typed_data//:LICENSE_FILES"],
     pub_pkg_name = "typed_data",
     deps = [
     ],
 )
-

--- a/vendor/utf/BUILD
+++ b/vendor/utf/BUILD
@@ -5,9 +5,9 @@ package(default_visibility = ["//visibility:public"])
 dart_library(
     name = "utf",
     srcs = [
-        "@utf//:utf"
+        "@vendor_utf//:utf"
     ],
-    license_files = ["@utf//:LICENSE_FILES"],
+    license_files = ["@vendor_utf//:LICENSE_FILES"],
     pub_pkg_name = "utf",
     deps = [
     ],


### PR DESCRIPTION
@natebosch @srawlins @jakemac53 

This includes some workarounds that Nate gave me last week to unblock the work for the summit codelab. 

You will need to edit your bazelify BUILD files manually to use the `focre_ddc_compile` flag. This is a temporary workaround while we wait to get internal library changes pushed to external.
