### PR TITLE
Eliminate unnecessary selects on host_cpu

### DIFF
--- a/dart/build_rules/templates/BUILD
+++ b/dart/build_rules/templates/BUILD
@@ -2,10 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dart_vm_binary",
-    srcs = select({
-        "//dart:darwin": ["dart_vm_binary.sh"],
-        "//dart:k8": ["dart_vm_binary.sh"],
-    }),
+    srcs = ["dart_vm_binary.sh"],
 )
 
 filegroup(
@@ -18,16 +15,10 @@ filegroup(
 
 filegroup(
     name = "dart_vm_test",
-    srcs = select({
-        "//dart:darwin": ["dart_vm_test.sh"],
-        "//dart:k8": ["dart_vm_test.sh"],
-    }),
+    srcs = ["dart_vm_test.sh"],
 )
 
 filegroup(
     name = "dart_vm_test_coverage",
-    srcs = select({
-        "//dart:darwin": ["dart_vm_test_coverage.sh"],
-        "//dart:k8": ["dart_vm_test_coverage.sh"],
-    }),
+    srcs = ["dart_vm_test_coverage.sh"],
 )

--- a/dart/build_rules/tools/BUILD
+++ b/dart/build_rules/tools/BUILD
@@ -2,10 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "dart2js_helper",
-    srcs = select({
-        "//dart:darwin": ["dart2js_helper.sh"],
-        "//dart:k8": ["dart2js_helper.sh"],
-    }),
+    srcs = ["dart2js_helper.sh"],
 )
 
 filegroup(


### PR DESCRIPTION
Restrict select() calls to cases where the underlying targets are
platform-specific.