### PR TITLE
Replace iteration over depsets with an explicit .to_list() call.

### DIFF
--- a/dart/build_rules/codegen/_codegen_action.bzl
+++ b/dart/build_rules/codegen/_codegen_action.bzl
@@ -326,7 +326,7 @@ def codegen_action(
             )
         arguments += [
             "--summary-files=%s" % summary.path
-            for summary in summaries
+            for summary in summaries.to_list()
         ]
         arguments += ["--dart-sdk-summary=%s" % sdk_summary.path]
 
@@ -400,7 +400,7 @@ def codegen_action(
         for ext in extensions
     ]
     ctx.actions.run(
-        inputs = list(inputs),
+        inputs = inputs.to_list(),
         outputs = outs,
         executable = generator_binary,
         progress_message = "Generating %s files %s " % (

--- a/dart/build_rules/common/context.bzl
+++ b/dart/build_rules/common/context.bzl
@@ -99,7 +99,7 @@ def make_dart_context(
     data = data or []
     data_files = depset([f for t in data for f in t.files])
     deps = deps or []
-    archive_srcs = list(srcs_files)
+    archive_srcs = srcs_files.to_list()
 
     archive = None
     if archive_srcs:
@@ -266,7 +266,7 @@ def _merge_dart_context(dart_ctx1, dart_ctx2):
         dart_srcs = dart_ctx1.dart_srcs + dart_ctx2.dart_srcs,
         data = dart_ctx1.data + dart_ctx2.data,
         deps = dart_ctx1.deps + dart_ctx2.deps,
-        license_files = list(depset(dart_ctx1.license_files + dart_ctx2.license_files)),
+        license_files = depset(dart_ctx1.license_files + dart_ctx2.license_files).to_list(),
         transitive_srcs_targets = dict(dart_ctx1.transitive_srcs.targets.items() + dart_ctx2.transitive_srcs.targets.items()),
         transitive_srcs_files = dart_ctx1.transitive_srcs.files + dart_ctx2.transitive_srcs.files,
         transitive_dart_srcs_files = dart_ctx1.transitive_dart_srcs.files + dart_ctx2.transitive_dart_srcs.files,


### PR DESCRIPTION
The old pattern did an implicit iteration over a depset which will be forbidden in the future since it is potentially expensive. The new to_list() call is still expensive but it will be more visible.